### PR TITLE
Add orNull to a HttpTry

### DIFF
--- a/httpmonads/src/main/java/com/nhaarman/httpmonads/HttpTry.kt
+++ b/httpmonads/src/main/java/com/nhaarman/httpmonads/HttpTry.kt
@@ -31,3 +31,8 @@ fun <R> HttpTry<R>.getOrElse(default: () -> R): R = when (this) {
     is HttpTry.Success -> value
     is HttpTry.Failure -> default()
 }
+
+fun <R> HttpTry<R>.orNull(): R? = when (this) {
+    is HttpTry.Success -> value
+    is HttpTry.Failure -> null
+}


### PR DESCRIPTION
So you don't have to use `.getOrElse{ null }`